### PR TITLE
Simplify printing of `ASCII`

### DIFF
--- a/burpa.py
+++ b/burpa.py
@@ -44,8 +44,7 @@ ASCII = r"""
                         /_/             
          burpa version 0.1 / by 0x4D31  
 
-###################################################
-"""
+###################################################"""
 PROXY_URL = None
 PROXY_PORT = None
 API_PORT = None
@@ -416,5 +415,5 @@ def main():
 
 
 if __name__ == '__main__':
-    print('\n'.join(ASCII.splitlines()))
+    print(ASCII)
     main()


### PR DESCRIPTION
```python
>>> ASCII = r"""
... ###################################################
...             __                          
...            / /_  __  ___________  ____ _
...           / __ \/ / / / ___/ __ \/ __ `/
...          / /_/ / /_/ / /  / /_/ / /_/ / 
...         /_.___/\__,_/_/  / .___/\__,_/  
...                         /_/             
...          burpa version 0.1 / by 0x4D31  
... 
... ###################################################
... """
>>> ASCII == '\n'.join(ASCII.splitlines())
False
>>> ASCII[:-1] == '\n'.join(ASCII.splitlines())
True
>>> ASCII = r"""
... ###################################################
...             __                          
...            / /_  __  ___________  ____ _
...           / __ \/ / / / ___/ __ \/ __ `/
...          / /_/ / /_/ / /  / /_/ / /_/ / 
...         /_.___/\__,_/_/  / .___/\__,_/  
...                         /_/             
...          burpa version 0.1 / by 0x4D31  
... 
... ###################################################"""
>>> ASCII == '\n'.join(ASCII.splitlines())
True
```